### PR TITLE
Tweaked form and made updating dates pre-populate

### DIFF
--- a/controllers/api/taskRoutes.js
+++ b/controllers/api/taskRoutes.js
@@ -258,7 +258,7 @@ router.delete(':id', withAuth, async (req, res) => {
   }
 })
 
-router.put(':id', withAuth, async (req, res) => {
+router.put('/:id', withAuth, async (req, res) => {
   try {
     const task_id = req.params.id;
     const taskToUpdate = await Task.findByPk(task_id);

--- a/controllers/homeRoutes.js
+++ b/controllers/homeRoutes.js
@@ -82,6 +82,7 @@ router.get('/task/:id', withAuth, async (req, res) => {
   } else {
     if (taskId) {
       const taskData = await Task.findByPk(taskId);
+      console.log(taskData.due_date);
       if (taskData.user_id === req.session.user_id) {
         res.render('task', {
           logged_in: req.session.logged_in,
@@ -114,11 +115,6 @@ router.get('/knockout/:time', async (req, res) => {
     try {
       /*  Get all of the task data for this user. */
       const taskData = await Task.findAll({
-        include: [
-          {
-            model: User
-          }
-        ],
         where: {
           user_id: req.session.user_id
         },

--- a/public/js/task.js
+++ b/public/js/task.js
@@ -1,21 +1,38 @@
 const taskFormHandler = async (event) => {
-  // TODO: Add a comment describing the functionality of this statement
+  // preventDefault keeps the form from clearing after submitting
   event.preventDefault();
-  const type = document.getElementById('type').value;
-  // TODO: Add a comment describing the functionality of these expressions
+  /** 
+   * Either "add" or "update".  From a hidden HTMLInputElement which passes along whether the page is creating a new task or updating an existing one
+   * @type {String}
+  */
+ const type = document.getElementById('type').value;
+    /** 
+   * Task title from input
+   * @type {String}
+  */
   const title = document.querySelector('#title-task').value.trim();
   const body = document.querySelector('#body-task').value.trim();
   var due_date;
-  if (document.querySelector('#due_date')) {
+  if (!document.querySelector('#due_date').value) {
     due_date = null;
   } else {
     due_date = new Date(document.querySelector('#due_date').value);
   }
   console.log("due date", due_date);
+
+  var complete_date;
+  if (type === 'update') {
+    if (!document.querySelector('#complete_date').value) {
+      complete_date = null;
+    } else {
+      complete_date = new Date(document.querySelector('#complete_date').value);
+    }
+}
+  
   const minutes = document.querySelector('#minutes').value;
   const points = document.querySelector('#points').value
-  const priority = document.querySelector('#priority').value;
- 
+
+  const priority = document.querySelector('#priority').value
 
   // console.log(due_date);
   if (title && body && priority && minutes && points) {
@@ -69,6 +86,66 @@ const taskFormHandler = async (event) => {
     
   }
 };
+
+
+
+
+const populateForm = () => {
+  /** 
+   * Either "add" or "update".  From a hidden HTMLInputElement which passes along whether the page is creating a new task or updating an existing one
+   * @type {String}
+  */
+ const type = document.getElementById('type').value;
+
+  /** @type {HTMLSelectElement} */
+  const priorityEl = document.querySelector('#priority');
+  const priority = priorityEl.getAttribute('data-value');
+
+  for (let x=0; x<6; x++) {
+    /** @type {HTMLOptionElement} */
+    const optionEl = document.createElement('option');
+    optionEl.style = "text-align: center;"
+    if (x!==0) {
+      optionEl.value = x;
+      optionEl.text = x;
+    } else if (type == 'add' || !priority) {
+      optionEl.selected = true;
+    }
+    if (x==priority) {
+      // if the option refers to the current priority value, remove "selected" status from the first option, and give it to the current option.
+      optionEl.selected=true;
+    }
+    priorityEl.appendChild(optionEl);
+  }
+
+  // Modify date values
+  // Somehow they're coming through in the .toLocaleString() format instead of ISO, even though it console.logs the ISO string on the server.
+  // This also ensures that a blank date isn't interpreted as 1970.
+  const dueDateEl = document.querySelector('#due_date');
+  let dueDate = dueDateEl.getAttribute('data-value');
+
+  if (dueDate) {
+    dueDate = new Date(dueDate);
+    if (dueDate.valueOf()) {
+      console.log(dueDate)
+      dueDateEl.value = dueDate.toISOString().slice(0,16);
+      console.log(dueDate)
+    }
+  }
+  if (type == 'update') {
+    const completeDateEl = document.querySelector('#complete_date');
+    let completeDate = completeDateEl.getAttribute('data-value');
+    if (completeDate) {
+      completeDate = new Date(completeDate);
+      if (+completeDate.valueOf()) {
+        completeDateEl.value = completeDate.toISOString().slice(0,16);
+      }
+    }
+    
+  }
+}
+
+populateForm();
 
 document
   .querySelector('.task-form')

--- a/public/js/task.js
+++ b/public/js/task.js
@@ -110,6 +110,7 @@ const populateForm = () => {
       optionEl.text = x;
     } else if (type == 'add' || !priority) {
       optionEl.selected = true;
+      optionEl.text = '-'
     }
     if (x==priority) {
       // if the option refers to the current priority value, remove "selected" status from the first option, and give it to the current option.

--- a/views/task.handlebars
+++ b/views/task.handlebars
@@ -14,9 +14,8 @@
         <input type="text" class="w-100 m-1 mx-0 form-control d-flex align-items-center"
           data-bs-toggle="tooltip" data-bs-placement="right" data-bs-custom-class="custom-tooltip" 
           data-bs-title="Please provide a unique title for your task that will help you differentiate it from any other task(s) that you create." id="title-task" aria-describedby="emailHelp"
-          placeholder="Enter task title" {{#if taskData.dataValues.title}}value="{{taskData.dataValues.title}}"{{/if}}/>
+          placeholder="Enter task title" {{#if taskData.dataValues.title}} value="{{taskData.dataValues.title}}"{{/if}}/>
       </div>
-
       <div class="form-group">
         <label for="body-task">Body</label>
         <textarea class="w-100 m-1 mx-0 form-control d-flex align-items-center"
@@ -30,33 +29,33 @@
         <label for="due_date">Due Date</label>
         <input class="w-100 m-1 mx-0 form-control d-flex align-items-center"
           data-bs-toggle="tooltip" data-bs-placement="right" data-bs-custom-class="custom-tooltip" 
-          data-bs-title="Please use the calendar to select the expected date of completion for your task." type="datetime-local" name="due_date" id="due_date" {{#if taskData.dataValues.due_date}}value="{{taskData.dataValues.due_date}}"{{/if}}>
+          data-bs-title="Please use the calendar to select the expected date of completion for your task." type="datetime-local" name="due_date" id="due_date" {{#if taskData.dataValues.due_date}} data-value="{{taskData.dataValues.due_date}}"{{/if}}>
       </div>
 
       <div class="form-group">
         <label for="priority">Priority</label>
-        <input class="w-100 m-1 mx-0 form-control d-flex align-items-center"
+        <select class="w-100 m-1 mx-0 form-control d-flex align-items-center"
           data-bs-toggle="tooltip" data-bs-placement="right" data-bs-custom-class="custom-tooltip" 
-          data-bs-title="Please assign a priority value for your task(with '1' being the highest value possible)." type="number" name="priority" id="priority"  {{#if taskData.dataValues.priority}}value="{{taskData.dataValues.priority}}"{{/if}}/>
+          data-bs-title="Please assign a priority value for your task(with '1' being the highest value possible)." type="number" name="priority" id="priority"  {{#if taskData.dataValues.priority}} data-value="{{taskData.dataValues.priority}}"{{/if}}></select>
       </div>
 
       <div class="form-group">
         <label for="points">Points</label>
         <input class="w-100 m-1 mx-0 form-control d-flex align-items-center"
           data-bs-toggle="tooltip" data-bs-placement="right" data-bs-custom-class="custom-tooltip" 
-          data-bs-title="Please provide the amount of points that you would like to receive as a reward, upon completion of this task." type="number" name="points" id="points" {{#if taskData.dataValues.points}}value="{{taskData.dataValues.points}}"{{/if}}/>
+          data-bs-title="Please provide the amount of points that you would like to receive as a reward, upon completion of this task." placeholder="amount of points task is worth" type="number" name="points" id="points" {{#if taskData.dataValues.points}}value="{{taskData.dataValues.points}}"{{/if}}/>
       </div>
 
       <div class="form-group">
         <label for="minutes">Minutes</label>
         <input class="w-100 m-1 mx-0 form-control d-flex align-items-center"
           data-bs-toggle="tooltip" data-bs-placement="right" data-bs-custom-class="custom-tooltip" 
-          data-bs-title="Please provide an approximate amount of time that this task will require to be completed(this data will be useful when utilizing the 'Knock Out' tool)." type="number" name="minutes" id="minutes" {{#if taskData.dataValues.minutes}}value="{{taskData.dataValues.minutes}}{{/if}}/>
+          data-bs-title="Please provide an approximate amount of time that this task will require to be completed(this data will be useful when utilizing the 'Knock Out' tool)." placeholder="time to complete" type="number" name="minutes" id="minutes" {{#if taskData.dataValues.minutes}}value="{{taskData.dataValues.minutes}}"{{/if}}/>
       </div>
       {{#if updateData}}
       <div class="form-group">
         <label for="complete_date">Completed</label>
-        <input class="w-100 m-1 mx-0 form-control" type="datetime-local" name="complete_date" id="complete_date" {{#if taskData.dataValues.complete_date}}value="{{taskData.dataValues.complete_date}}"{{/if}}/>
+        <input class="w-100 m-1 mx-0 form-control" type="datetime-local" name="complete_date" id="complete_date" {{#if taskData.dataValues.complete_date}}data-value="{{taskData.complete_date}}"{{/if}}/>
       </div>
       {{/if}}
       <div class="form-group">


### PR DESCRIPTION
It was surprisingly annoying to get the dates to fill in correctly.  Somehow from the database to rendering in handlebars, it changes it to toLocaleString() format.

I made a really roundabout fix as I was trying to figure out where the problem was.  It does do the job.

I now have figured out that it's sequelize and handlebars trying to be too helpful, and if I could go back, I would fix it there instead of in the public js script.